### PR TITLE
Missing features added + New Features + Code cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 .env
 .vsc
 abc.*
-data/relicdata.json
-data/userids.json
+data/*.json

--- a/data/utils.js
+++ b/data/utils.js
@@ -40,7 +40,7 @@ function checkForRelic(relic) {
  * @param {Client} client 
  */
 async function updateFissures(client) {
-  const channel = await client.channels.cache.get(fissureChannel).messages.fetch({ limit: 4 })
+  const channel = await client.channels.cache.get(fissureChannel).messages.fetch({ limit: 2 })
   const missions = ['Extermination', 'Capture', 'Sabotage', 'Rescue']
   const response = (await axios.get("https://api.warframestat.us/pc/fissures")).data.filter(
     (f) => !f["isStorm"] && missions.includes(f["missionType"]) && f['active']
@@ -50,16 +50,11 @@ async function updateFissures(client) {
   const activeEras = fissures.map(x => `${x[0]}${x[2]}`)
 
   const NormEmbed = new EmbedBuilder().setTitle('Normal Fissures');
-  !activeEras.some(x => x == 'Lithfalse') || NormEmbed.addFields({ name: 'Lith', value: fissures.filter(x => x[0] == 'Lith' && !x[2]).map(x => x[1]).join('\n') });
-  !activeEras.some(x => x == 'Mesofalse') || NormEmbed.addFields({ name: 'Meso', value: fissures.filter(x => x[0] == 'Meso' && !x[2]).map(x => x[1]).join('\n') });
-  !activeEras.some(x => x == 'Neofalse') || NormEmbed.addFields({ name: 'Neo', value: fissures.filter(x => x[0] == 'Neo' && !x[2]).map(x => x[1]).join('\n') });
-  !activeEras.some(x => x == 'Axifalse') || NormEmbed.addFields({ name: 'Axi', value: fissures.filter(x => x[0] == 'Axi' && !x[2]).map(x => x[1]).join('\n') });
-
   const SPEmbed = new EmbedBuilder().setTitle('Steel Path fissures').setTimestamp();
-  !activeEras.some(x => x == 'Lithtrue') || SPEmbed.addFields({ name: 'Lith', value: fissures.filter(x => x[0] == 'Lith' && x[2]).map(x => x[1]).join('\n') });
-  !activeEras.some(x => x == 'Mesotrue') || SPEmbed.addFields({ name: 'Meso', value: fissures.filter(x => x[0] == 'Meso' && x[2]).map(x => x[1]).join('\n') });
-  !activeEras.some(x => x == 'Neotrue') || SPEmbed.addFields({ name: 'Neo', value: fissures.filter(x => x[0] == 'Neo' && x[2]).map(x => x[1]).join('\n') });
-  !activeEras.some(x => x == 'Axitrue') || SPEmbed.addFields({ name: 'Axi', value: fissures.filter(x => x[0] == 'Axi' && x[2]).map(x => x[1]).join('\n') });
+  ['Lith', 'Meso', 'Neo', 'Axi'].forEach(f => {
+    !activeEras.some(x => x == `${f}false`) || NormEmbed.addFields({ name: f, value: fissures.filter(x => x[0] == f && !x[2]).map(x => x[1]).join('\n') });
+    !activeEras.some(x => x == `${f}true`) || SPEmbed.addFields({ name: f, value: fissures.filter(x => x[0] == f && x[2]).map(x => x[1]).join('\n') });
+  })
 
   await channel.forEach(async (msg) => msg.author.id == client.user.id ? (await msg.edit({ embeds: [NormEmbed, SPEmbed] })) : null)
 }

--- a/events/components/thost-button.js
+++ b/events/components/thost-button.js
@@ -2,6 +2,7 @@ const {
     Client,
     EmbedBuilder,
     ButtonInteraction,
+    codeBlock
 } = require("discord.js");
 const fs = require('node:fs')
 
@@ -51,9 +52,9 @@ module.exports = {
                 if (setOfUsers.indexOf(i.user.id) === -1) return i.update({ });
 
                 else if (i.user.id == i.message.content.slice(3, -1)) {
-                    i.update({ content: null });
-                    i.deleteReply();
-                    i.channel.send({
+                    await i.update({ content: null });
+                    await i.deleteReply();
+                    await i.channel.send({
                         embeds: [new EmbedBuilder().setTitle(`Run for ${relic} is cancelled`)],
                     });
                     return;
@@ -65,6 +66,35 @@ module.exports = {
                     i.update({ embeds: [relicEmbed] });
                 }
                 break;
+
+            case 'thost-relicview':
+                const types = { 
+                    "#150b2e": "ED",
+                    "#3c0000": "RED",
+                    "#472502": "ORANGE",
+                    "#4b3800": "YELLOW",
+                    "#162e0b": "GREEN",
+                    "#282828": undefined
+                };
+                const relicName = relic.split('x ')[1].slice(0, -1)
+                let jsfile = await JSON.parse(await fs.readFileSync('./data/relicdata.json', 'utf-8'))
+                const relicInfo = jsfile.filter(x => x[0][0] == relicName)[0].map(x => [x[0], types[x[1]]])
+                const rarities = ['C', 'C', 'C', 'UC', 'UC', 'RA']
+                
+                const itemCounts = relicInfo.slice(1, -1).map(x => x[0].slice(x[0].indexOf('[')+1, -1))
+                const itemNames = relicInfo.slice(1, -1).map(x => (x[0].slice(0, x[0].indexOf('[') != -1 ? x[0].indexOf('[')-1 : 100) + `${x[1] ? ` {${x[1]}}` : ''}`))
+                let embedDesc = ""
+                for (r=0;r<6;r++) {
+                    if (isNaN(parseInt(itemCounts[r])))
+                        embedDesc += `${rarities[r].padEnd(2)} |    | ${itemNames[r]}\n`
+                    else {
+                        embedDesc += `${rarities[r].padEnd(2)} | ${itemCounts[r].padEnd(3)}| ${itemNames[r]}\n`
+                    }
+                }
+
+                await i.update({ })
+                await i.user.send({ embeds: [new EmbedBuilder().setTitle(`[ ${relicName} ]`).setDescription(codeBlock('ml', embedDesc)).setTimestamp()] })
+                    .catch((error) => { return; })
         }
     },
 }

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -33,7 +33,6 @@ module.exports = {
         }
         
         else if (interaction.isButton()) {
-            if (interaction.message.createdTimestamp < client.startuptime) return;
             const button = client.buttons.get(interaction.customId.split('-')[0])
             if (!button) return
             try {

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,6 +1,5 @@
 const { Client, ActivityType } = require('discord.js')
 const { alert, err } = require('../data/utils');
-const { spreadsheet } = require('../configs/config.json')
 
 module.exports = {
     name: 'ready', 

--- a/treasury/messagetype/refresh.js
+++ b/treasury/messagetype/refresh.js
@@ -30,6 +30,7 @@ module.exports = {
             });
 
             const values = response.data.values;
+            if (values.some(x => x[0] == '#ERROR!' || x[1] == '#ERROR!')) return
 
             if (values && values.length > 0) {
                 await fs.promises.writeFile('./data/userids.json', JSON.stringify(values.filter(x => x.length != 0)))
@@ -50,6 +51,7 @@ module.exports = {
             });
 
             const values = response.data.values;
+            if (values.some(x => x[0][0] == '#ERROR!' || x[0][1] == '#ERROR!')) return
 
             if (values && values.length > 0) {
                 // Fetch background colors separately

--- a/treasury/messagetype/soup.js
+++ b/treasury/messagetype/soup.js
@@ -61,15 +61,16 @@ module.exports = {
 
         const msgfilter = message.content.toLowerCase().split(' ').slice(1)
         const relics = msgfilter.splice(msgfilter.indexOf('soup')+1).join('_')
-        const soupedRelics = (await soupedType(relics)).sort((a, b) => a.localeCompare(b))
+        const soupedRelics = (await soupedType(relics)).sort((a, b) => a.localeCompare(b) && b.split(' | ')[2].replace(' ED', '') - a.split(' | ')[2].replace(' ED', ''))
         const axirelics = [... new Set(soupedRelics.filter(x => x.indexOf(`Axi`) !== -1))]
         const neorelics = [... new Set(soupedRelics.filter(x => x.indexOf(`Neo`) !== -1))]
         const mesorelics = [... new Set(soupedRelics.filter(x => x.indexOf(`Meso`) !== -1))]
         const lithrelics = [... new Set(soupedRelics.filter(x => x.indexOf(`Lith`) !== -1))]
+        const relicsFinal = [axirelics, neorelics, mesorelics, lithrelics]
         response.edit({ embeds: [
             new EmbedBuilder()
             .setTitle(`Soup formatted`)
-            .setDescription(`${codeBlock('ml', `${axirelics.length !== 0? axirelics.join('\n')+'\n\n' : ''}${neorelics.length !== 0? neorelics.join('\n')+'\n\n' : ''}${mesorelics.length !== 0? mesorelics.join('\n')+'\n\n' : ''}${lithrelics.length !== 0? lithrelics.join('\n')+'\n\n' : ''}`)}\n\n*CODE: ${validrelics.join(' ')}*`)
+            .setDescription(codeBlock('ml', relicsFinal.map(rl => rl.length !== 0 ? `${rl.join('\n')}\n\n` : '').join('')) + `\n\n*CODE: ${validrelics.join(' ')}*`)
         ], content: content.length == 0? null : `Duplicates found: ${content.join(' ')}` })
     }
 }

--- a/treasury/slashtype/thost.js
+++ b/treasury/slashtype/thost.js
@@ -28,6 +28,13 @@ module.exports = {
                 .setName("relic")
                 .setDescription("Name of the relic you want to host")
                 .setRequired(true)
+        )
+        .addStringOption((option) =>
+        option
+            .setName("type")
+            .setDescription("Type of run")
+            .setRequired(false)
+            .setChoices({ name: 'Normal', value: 'norm' }, { name: 'Bois Run', value: 'bois' })
         ),
     /**
      * Treasury exclusive command to host runs; to squad up
@@ -46,6 +53,7 @@ module.exports = {
 
         // Handling interaction
         const relic = interaction.options.getString("relic", true).toLowerCase(),
+            runType = interaction.options.getString("type", false) ?? undefined,
             relicCount = interaction.options.getInteger("count", true);
 
         const relicStuff = parseString(relic, relicData);
@@ -59,7 +67,7 @@ module.exports = {
 
             relicDesc = `\`${relicCount}x ${relicStuff}\`\n`
             const relicEmbed = new EmbedBuilder()
-                .setTitle(`Squad by ${interaction.member.nickname ?? interaction.member.user.username}`);
+                .setTitle(`${runType == 'norm' || !runType ? 'Squad' : 'Bois run'} by ${interaction.member.nickname ?? interaction.member.user.username}`);
 
             const confirm = new ButtonBuilder()
                 .setCustomId('thost-join')
@@ -71,9 +79,14 @@ module.exports = {
                 .setLabel('❌')
                 .setStyle(ButtonStyle.Danger);
 
+            const relicView = new ButtonBuilder()
+                .setCustomId('thost-relicview')
+                .setLabel(relicStuff)
+                .setStyle(ButtonStyle.Primary)
+
             relicDesc += `${setOfUsers.map(x => `<@!${x}>`).join("\n")}`
 
-            const hostButtons = new ActionRowBuilder().addComponents(confirm, cancel)
+            const hostButtons = new ActionRowBuilder().addComponents(confirm, cancel, relicView)
 
             relicEmbed.setDescription(relicDesc)
             interaction.reply({ content: `Successfully hosted a run for ${relicStuff}`, ephemeral: true });


### PR DESCRIPTION
Added:
+ Button on thost to check relic being hosted
+ Soup command sorting, and duplicate detection
+ Ability to check stock of prime sets
+ Ability to alternate between short hand and long hand form of relic names, across the bot
+ thost join protection
+ Sheet error protection
+ Ability to select which type of run to host (bois/normal)
+ text in fissure embed to understand the time better

Removed:
- JSON files in git pushes
- Client timeout restrictions for buttons on restart
- Redundant code that wasted lines